### PR TITLE
Ruby 2.5.0でbundle installに失敗するのを修正

### DIFF
--- a/dashboard/Gemfile
+++ b/dashboard/Gemfile
@@ -62,5 +62,5 @@ gem 'font-awesome-rails'
 # For development
 group :development do
   gem 'ruby-debug-ide'
-  gem 'debase'
+  gem 'debase', '~> 0.2.2'
 end


### PR DESCRIPTION
debaseのバージョンが古いと失敗するため新しいものを指定するように変更しています。
Ruby 2.3.3でもこのバージョンのdebaseで動作するようです（先ほど送ったpull requestのテストは通ることを確認しています）。